### PR TITLE
feat : remove SysV init and bash

### DIFF
--- a/configs/milkv_duo_musl_riscv64_defconfig
+++ b/configs/milkv_duo_musl_riscv64_defconfig
@@ -13,9 +13,7 @@ BR2_TARGET_LDFLAGS="-march=rv64imafdc_xtheadba_xtheadbb_xtheadbs_xtheadcmo_xthea
 BR2_GLOBAL_PATCH_DIR="board/milkv/duo/patches"
 BR2_TARGET_GENERIC_HOSTNAME="milkv-duo"
 BR2_TARGET_GENERIC_ISSUE="Welcome to Milk-V"
-BR2_INIT_SYSV=y
 BR2_TARGET_GENERIC_ROOT_PASSWD="milkv"
-BR2_SYSTEM_BIN_SH_BASH=y
 BR2_ROOTFS_OVERLAY="board/milkv/duo/overlay"
 BR2_ROOTFS_POST_IMAGE_SCRIPT="board/milkv/duo/post-image.sh"
 BR2_LINUX_KERNEL=y


### PR DESCRIPTION
Busybox will be used as init and shell (ash), like in official sdk.