### PR TITLE
fix: change TERM to xterm-256color

### DIFF
--- a/board/milkv/duo/overlay/etc/profile
+++ b/board/milkv/duo/overlay/etc/profile
@@ -32,5 +32,5 @@ alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
-export TERM=vt100
+export TERM=xterm-256color
 export TERMINFO=/usr/share/terminfo


### PR DESCRIPTION
With terminal set to `vt100` some programs (like mc or htop) looks bad and function keys don't work (left image) : 

![Screenshot from 2023-10-31 10-51-10](https://github.com/gtxzsxxk/duo-buildroot/assets/23244044/c1f3acc5-4603-4d2d-a942-eb8f0beb72c3)

After changing it to `xterm-256color` (right image) everything is OK.