### PR TITLE
feat: add ability to run scripts once

### DIFF
--- a/board/milkv/duo/overlay/etc/init.d/S05runonce
+++ b/board/milkv/duo/overlay/etc/init.d/S05runonce
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#
+# Execute scripts, that are intended to run only once
+#
+case "$1" in
+  start)
+
+        for file in /etc/runonce.d/*
+        do
+                if [ ! -f "$file" ]
+                then
+                        continue
+                fi
+                
+                if "$file" >> /tmp/runonce.log 2>&1
+                then
+                        mv "$file" "/etc/runonce.d/ran/"
+                fi
+        done
+        ;;
+  stop)
+        ;;
+  restart|reload)
+        ;;
+  *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+esac
+
+exit $?


### PR DESCRIPTION
This commit adds ability to single execution of scripts, that are placed in `/etc/runonce.d` directory. If script successed, it's moved to subdirectory `ran`, errors are logged to `/tmp/runonce.log`